### PR TITLE
Add TLS support

### DIFF
--- a/packaging/docker/authenticator/Dockerfile
+++ b/packaging/docker/authenticator/Dockerfile
@@ -14,10 +14,10 @@ RUN go build -o /authenticator ./cmd/authenticator/main.go
 FROM alpine:3.8 as runtime
 MAINTAINER OpenSource PF <opensource@postfinance.ch>
 
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
 COPY --from=builder /authenticator /authenticator
 
 # Run as nobody:x:65534:65534:nobody:/:/sbin/nologin
 USER 65534
 
 CMD ["/authenticator"]
-

--- a/packaging/docker/authenticator/Dockerfile
+++ b/packaging/docker/authenticator/Dockerfile
@@ -5,7 +5,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 
 WORKDIR /vgo/
-COPY . .
+COPY ./cmd ./cmd
 
 RUN ls -al
 RUN go build -o /authenticator ./cmd/authenticator/main.go

--- a/packaging/docker/synchronizer/Dockerfile
+++ b/packaging/docker/synchronizer/Dockerfile
@@ -5,7 +5,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 
 WORKDIR /vgo/
-COPY . .
+COPY ./cmd ./cmd
 
 RUN go build -o /synchronizer ./cmd/synchronizer/main.go
 

--- a/packaging/docker/synchronizer/Dockerfile
+++ b/packaging/docker/synchronizer/Dockerfile
@@ -13,10 +13,10 @@ RUN go build -o /synchronizer ./cmd/synchronizer/main.go
 FROM alpine:3.8 as runtime
 MAINTAINER OpenSource PF <opensource@postfinance.ch>
 
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
 COPY --from=builder /synchronizer /synchronizer
 
 # Run as nobody:x:65534:65534:nobody:/:/sbin/nologin
 USER 65534
 
 CMD ["/synchronizer"]
-

--- a/packaging/docker/token-renewer/Dockerfile
+++ b/packaging/docker/token-renewer/Dockerfile
@@ -14,10 +14,10 @@ RUN go build -o /token-renewer ./cmd/token-renewer/main.go
 FROM alpine:3.8 as runtime
 MAINTAINER OpenSource PF <opensource@postfinance.ch>
 
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
 COPY --from=builder /token-renewer /token-renewer
 
 # Run as nobody:x:65534:65534:nobody:/:/sbin/nologin
 USER 65534
 
 CMD ["/token-renewer"]
-

--- a/packaging/docker/token-renewer/Dockerfile
+++ b/packaging/docker/token-renewer/Dockerfile
@@ -5,7 +5,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 
 WORKDIR /vgo/
-COPY . .
+COPY ./cmd ./cmd
 
 RUN ls -al
 RUN go build -o /token-renewer ./cmd/token-renewer/main.go


### PR DESCRIPTION
In this PR:
- Add TLS support for Vault client: add `ca-certificates` package, without this, request to TLS Vault server will result `x509: certificate signed by unknown authority`
- Make build faster: only copy source code to builder image, this allows us to change files outside source code without triggering the whole dependency pulling.