### PR TITLE
More proper error message that do not confuses developer

### DIFF
--- a/cmd/synchronizer/main.go
+++ b/cmd/synchronizer/main.go
@@ -122,7 +122,7 @@ func (sc *syncConfig) checkSecrets() error {
 		log.Println("check k8s secret", k, "from vault secret", v)
 		_, err := sc.k8sClientset.CoreV1().Secrets(sc.Namespace).Get(k, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("secret %s does not exist", k)
+			return fmt.Errorf("could not fetch secret %s from namespace %s: %s", k, sc.Namespace, err.Error())
 		}
 	}
 	return nil


### PR DESCRIPTION
My ServiceAccount had no access to get secrets in certain namespace, I had permissions problem.  But I was receiving error message "secret app1-secrets does not exist" which was very confusing. Secret `app1-secrets` definitely exists in namespace. Please change confusing error message.