### PR TITLE
fix(decode): fixing decode function for base64 secrets

### DIFF
--- a/cmd/synchronizer/main.go
+++ b/cmd/synchronizer/main.go
@@ -334,7 +334,7 @@ func getEnv(key, fallback string) string {
 func decode(s string) ([]byte, error) {
 	switch {
 	case strings.HasPrefix(s, "base64:"):
-		return base64.StdEncoding.DecodeString(strings.TrimLeft(s, "base64:"))
+		return base64.StdEncoding.DecodeString(strings.TrimPrefix(s, "base64:"))
 	default:
 		return []byte(s), nil
 	}

--- a/cmd/synchronizer/main_test.go
+++ b/cmd/synchronizer/main_test.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	quote = "The fool don‘t think he is wise, but the wise man knows himself to be a fool."
+	trivialString = "h"
 )
 
 func TestDecode(t *testing.T) {
@@ -25,6 +26,13 @@ func TestDecode(t *testing.T) {
 		res, err := decode(str)
 		assert.NoError(t, err)
 		assert.Equal(t, quote, string(res))
+	})
+
+	t.Run("base64 encoded", func(t *testing.T) {
+		str := "base64:" + base64.StdEncoding.EncodeToString([]byte(trivialString))
+		res, err := decode(str)
+		assert.NoError(t, err)
+		assert.Equal(t, trivialString, string(res))
 	})
 
 	t.Run("base64 decode fails", func(t *testing.T) {


### PR DESCRIPTION
This PR replaces the `TrimLeft` function with `TrimPrefix` during the decode phase of base64 secrets (prepended with the `base64:` string).

The problem of `TrimLeft` is that it replaces all the occurrences of the characters defined in `base64:`, which is not desired. For instance, `base64("h")` = "aA==". Then, `strings.TrimPrefix(s, "base64:")` = "A==". This results in a an error when trying to decode secrets of this kind (`illegal base64 data at input byte`).

The added test case fails without this fix:
```
--- FAIL: TestDecode (0.00s)
    --- FAIL: TestDecode/base64_encoded#01 (0.00s)
        main_test.go:34:
            	Error Trace:	main_test.go:34
            	Error:      	Received unexpected error:
            	            	illegal base64 data at input byte 1
            	Test:       	TestDecode/base64_encoded#01
        main_test.go:35:
            	Error Trace:	main_test.go:35
            	Error:      	Not equal:
            	            	expected: "h"
            	            	actual  : ""

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-h
            	            	+
            	Test:       	TestDecode/base64_encoded#01
FAIL
exit status 1
FAIL	github.com/postfinance/vault-kubernetes/cmd/synchronizer	0.409s
```